### PR TITLE
Change link to point to correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Gradle Plugin to create lifecycle tasks that trigger `yarn run` commands.
 
 Usage
 -----
-1. [Apply the plugin](https://plugins.gradle.org/plugin/com.palantir.npm-run)
+1. [Apply the plugin](https://plugins.gradle.org/plugin/com.nickcharles.yarn-run)
 1. Add `yarn` to your `devDependencies` block in your `package.json`
 1. Configure your `package.json` `scripts` block
 


### PR DESCRIPTION
Currently, the link for applying the plug-in points to the npm-run plug-in provided by Palantir, not this plug-in